### PR TITLE
Refactor code to declare interfaces locally

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -19,17 +19,45 @@ import (
 	"gitlab.uis.dev/service/gocron/internal/worker"
 )
 
+// Querier defines the interface for database query operations.
+type Querier interface {
+	CreateJob(ctx context.Context, arg postgres.CreateJobParams) (postgres.Job, error)
+	CreateJobLog(ctx context.Context, arg postgres.CreateJobLogParams) (postgres.JobLog, error)
+	DeleteJob(ctx context.Context, id int64) error
+	GetActiveJobs(ctx context.Context) ([]postgres.Job, error)
+	GetJob(ctx context.Context, id int64) (postgres.Job, error)
+	GetJobByCustomID(ctx context.Context, customID pgtype.Text) (postgres.Job, error)
+	GetJobLogs(ctx context.Context, arg postgres.GetJobLogsParams) ([]postgres.JobLog, error)
+	ProcessJob(ctx context.Context, id int64) (postgres.Job, error)
+	UpdateJobAfterExecution(ctx context.Context, arg postgres.UpdateJobAfterExecutionParams) (postgres.Job, error)
+	UpdateJobStatus(ctx context.Context, arg postgres.UpdateJobStatusParams) (postgres.Job, error)
+}
+
+// Storer defines the interface for database operations, including transactions.
+type Storer interface {
+	Querier
+	ExecTx(ctx context.Context, fn func(*postgres.Queries) error) error
+}
+
+// ManagerInterface defines the interface for a worker manager.
+// It allows for mocking in tests.
+type ManagerInterface interface {
+	Publish(ctx context.Context, jobID int64, delay time.Duration) error
+	Start(ctx context.Context)
+	Stop()
+}
+
 // Scheduler handles the core business logic of scheduling and running jobs.
 type Scheduler struct {
 	log    *slog.Logger
 	cfg    config.SchedulerConfig
-	store  postgres.Storer
-	worker worker.ManagerInterface
+	store  Storer
+	worker ManagerInterface
 	client *http.Client
 }
 
 // New creates a new Scheduler.
-func New(log *slog.Logger, cfg config.Config, store postgres.Storer) (*Scheduler, error) {
+func New(log *slog.Logger, cfg config.Config, store Storer) (*Scheduler, error) {
 	s := &Scheduler{
 		log:    log,
 		cfg:    cfg.Scheduler,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -16,7 +16,7 @@ import (
 	"gitlab.uis.dev/service/gocron/internal/storage/postgres"
 )
 
-// MockWorkerManager is a mock implementation of the worker.ManagerInterface for testing.
+// MockWorkerManager is a mock implementation of the ManagerInterface for testing.
 type MockWorkerManager struct {
 	PublishedJobs map[int64]time.Duration
 }
@@ -42,7 +42,7 @@ func (m *MockWorkerManager) Stop() {}
 
 var (
 	testScheduler *Scheduler
-	testStore     postgres.Storer
+	testStore     Storer
 	mockWorker    *MockWorkerManager
 	testPool      *pgxpool.Pool
 )

--- a/internal/storage/postgres/db.go
+++ b/internal/storage/postgres/db.go
@@ -5,17 +5,8 @@
 package postgres
 
 import (
-	"context"
-
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 )
-
-type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
-}
 
 func New(db DBTX) *Queries {
 	return &Queries{db: db}

--- a/internal/storage/postgres/querier.go
+++ b/internal/storage/postgres/querier.go
@@ -7,20 +7,14 @@ package postgres
 import (
 	"context"
 
-	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-type Querier interface {
-	CreateJob(ctx context.Context, arg CreateJobParams) (Job, error)
-	CreateJobLog(ctx context.Context, arg CreateJobLogParams) (JobLog, error)
-	DeleteJob(ctx context.Context, id int64) error
-	GetActiveJobs(ctx context.Context) ([]Job, error)
-	GetJob(ctx context.Context, id int64) (Job, error)
-	GetJobByCustomID(ctx context.Context, customID pgtype.Text) (Job, error)
-	GetJobLogs(ctx context.Context, arg GetJobLogsParams) ([]JobLog, error)
-	ProcessJob(ctx context.Context, id int64) (Job, error)
-	UpdateJobAfterExecution(ctx context.Context, arg UpdateJobAfterExecutionParams) (Job, error)
-	UpdateJobStatus(ctx context.Context, arg UpdateJobStatusParams) (Job, error)
+type DBTX interface {
+	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...interface{}) pgx.Row
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/storage/postgres/store.go
+++ b/internal/storage/postgres/store.go
@@ -3,13 +3,22 @@ package postgres
 import (
 	"context"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// Storer defines the interface for database operations, including transactions.
-type Storer interface {
-	Querier
-	ExecTx(ctx context.Context, fn func(*Queries) error) error
+// Querier defines the interface for database query operations.
+type Querier interface {
+	CreateJob(ctx context.Context, arg CreateJobParams) (Job, error)
+	CreateJobLog(ctx context.Context, arg CreateJobLogParams) (JobLog, error)
+	DeleteJob(ctx context.Context, id int64) error
+	GetActiveJobs(ctx context.Context) ([]Job, error)
+	GetJob(ctx context.Context, id int64) (Job, error)
+	GetJobByCustomID(ctx context.Context, customID pgtype.Text) (Job, error)
+	GetJobLogs(ctx context.Context, arg GetJobLogsParams) ([]JobLog, error)
+	ProcessJob(ctx context.Context, id int64) (Job, error)
+	UpdateJobAfterExecution(ctx context.Context, arg UpdateJobAfterExecutionParams) (Job, error)
+	UpdateJobStatus(ctx context.Context, arg UpdateJobStatusParams) (Job, error)
 }
 
 // Store provides all functions to execute db queries and transactions
@@ -19,7 +28,7 @@ type Store struct {
 }
 
 // NewStore creates a new Store
-func NewStore(pool *pgxpool.Pool) Storer {
+func NewStore(pool *pgxpool.Pool) *Store {
 	return &Store{
 		pool:    pool,
 		Queries: New(pool),

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,14 +1,1 @@
 package worker
-
-import (
-	"context"
-	"time"
-)
-
-// ManagerInterface defines the interface for a worker manager.
-// It allows for mocking in tests.
-type ManagerInterface interface {
-	Publish(ctx context.Context, jobID int64, delay time.Duration) error
-	Start(ctx context.Context)
-	Stop()
-}


### PR DESCRIPTION
Move interfaces (`Querier`, `Storer`, `ManagerInterface`, `DBTX`) to their points of use to improve locality and reduce dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0d141c3-4e1b-4713-a4dc-2eee65d47b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0d141c3-4e1b-4713-a4dc-2eee65d47b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

